### PR TITLE
Feature/unify sync async

### DIFF
--- a/examples/handshake-boxstream-bench-async.rs
+++ b/examples/handshake-boxstream-bench-async.rs
@@ -44,17 +44,17 @@ async fn main() -> Result<(), Error> {
 
     let (handshake, socket) = match mode {
         "client" => {
-            let socket = TcpStream::connect(addr).await?;
+            let mut socket = TcpStream::connect(addr).await?;
 
-            let (_,  handshake) =
-                handshake_client(&socket, net_id, client_pk, client_sk, server_pk).await?;
+            let handshake =
+                handshake_client(&mut socket, net_id, client_pk, client_sk, server_pk).await?;
             (handshake, socket)
         }
         "server" => {
             let listener = TcpListener::bind(addr).await?;
-            let (socket, _) = listener.accept().await?;
+            let (mut socket, _) = listener.accept().await?;
 
-            let handshake = handshake_server(&socket, net_id, server_pk, server_sk).await?;
+            let handshake = handshake_server(&mut socket, net_id, server_pk, server_sk).await?;
             (handshake, socket)
         }
         _ => {

--- a/examples/handshake-boxstream-bench-sync.rs
+++ b/examples/handshake-boxstream-bench-sync.rs
@@ -44,17 +44,17 @@ fn main() {
 
     let (handshake, socket) = match mode {
         "client" => {
-            let socket = TcpStream::connect(addr).unwrap();
+            let mut socket = TcpStream::connect(addr).unwrap();
 
             let handshake =
-                handshake_client(&socket, net_id, client_pk, client_sk, server_pk).unwrap();
+                handshake_client(&mut socket, net_id, client_pk, client_sk, server_pk).unwrap();
             (handshake, socket)
         }
         "server" => {
             let listener = TcpListener::bind(addr).unwrap();
-            let (socket, _) = listener.accept().unwrap();
+            let (mut socket, _) = listener.accept().unwrap();
 
-            let handshake = handshake_server(&socket, net_id, server_pk, server_sk).unwrap();
+            let handshake = handshake_server(&mut socket, net_id, server_pk, server_sk).unwrap();
             (handshake, socket)
         }
         _ => {

--- a/examples/handshake-boxstream.rs
+++ b/examples/handshake-boxstream.rs
@@ -1,6 +1,6 @@
 extern crate base64;
-extern crate kuska_handshake;
 extern crate crossbeam;
+extern crate kuska_handshake;
 
 use std::env;
 use std::io::{self};
@@ -10,9 +10,9 @@ use crossbeam::thread;
 use log::debug;
 use sodiumoxide::crypto::{auth, sign::ed25519};
 
-use kuska_handshake::{KeyNonce,SharedSecret};
 use kuska_handshake::sync::BoxStream;
 use kuska_handshake::sync::{self, handshake_client, handshake_server};
+use kuska_handshake::{KeyNonce, SharedSecret};
 
 fn usage(arg0: &str) {
     eprintln!(
@@ -32,12 +32,12 @@ fn print_shared_secret(shared_secret: &SharedSecret) {
 }
 
 fn test_server(
-    socket: TcpStream,
+    mut socket: TcpStream,
     net_id: auth::Key,
     pk: ed25519::PublicKey,
     sk: ed25519::SecretKey,
 ) -> sync::Result<()> {
-    let handshake = handshake_server(&socket, net_id, pk, sk)?;
+    let handshake = handshake_server(&mut socket, net_id, pk, sk)?;
     println!("Handshake complete! 💃");
     debug!("{:#?}", handshake);
     print_shared_secret(&handshake.shared_secret);
@@ -63,13 +63,13 @@ fn test_server(
 }
 
 fn test_client(
-    socket: TcpStream,
+    mut socket: TcpStream,
     net_id: auth::Key,
     pk: ed25519::PublicKey,
     sk: ed25519::SecretKey,
     server_pk: ed25519::PublicKey,
 ) -> sync::Result<()> {
-    let handshake = handshake_client(&socket, net_id, pk, sk, server_pk)?;
+    let handshake = handshake_client(&mut socket, net_id, pk, sk, server_pk)?;
     println!("Handshake complete! 💃");
     debug!("{:#?}", handshake);
     print_shared_secret(&handshake.shared_secret);

--- a/examples/handshake.rs
+++ b/examples/handshake.rs
@@ -5,8 +5,8 @@ use sodiumoxide::crypto::{auth, sign::ed25519};
 use std::env;
 use std::net::{TcpListener, TcpStream};
 
-use kuska_handshake::SharedSecret;
 use kuska_handshake::sync::{self, handshake_client, handshake_server};
+use kuska_handshake::SharedSecret;
 
 fn usage(arg0: &str) {
     eprintln!(
@@ -26,12 +26,12 @@ fn print_shared_secret(shared_secret: &SharedSecret) {
 }
 
 fn test_server(
-    socket: TcpStream,
+    mut socket: TcpStream,
     net_id: auth::Key,
     pk: ed25519::PublicKey,
     sk: ed25519::SecretKey,
 ) -> sync::Result<()> {
-    let handshake = handshake_server(&socket, net_id, pk, sk)?;
+    let handshake = handshake_server(&mut socket, net_id, pk, sk)?;
     println!("Handshake complete! 💃");
     println!("{:#?}", handshake);
     print_shared_secret(&handshake.shared_secret);
@@ -39,13 +39,13 @@ fn test_server(
 }
 
 fn test_client(
-    socket: TcpStream,
+    mut socket: TcpStream,
     net_id: auth::Key,
     pk: ed25519::PublicKey,
     sk: ed25519::SecretKey,
     server_pk: ed25519::PublicKey,
 ) -> sync::Result<()> {
-    let handshake = handshake_client(&socket, net_id, pk, sk, server_pk)?;
+    let handshake = handshake_client(&mut socket, net_id, pk, sk, server_pk)?;
     println!("Handshake complete! 💃");
     println!("{:#?}", handshake);
     print_shared_secret(&handshake.shared_secret);

--- a/src/async_std/boxstream.rs
+++ b/src/async_std/boxstream.rs
@@ -60,6 +60,19 @@ impl<R: Read + Unpin, W: Write + Unpin> BoxStream<R, W> {
         (reader, writer)
     }
 
+    pub fn new(
+        read_stream: R,
+        write_stream: W,
+        key_nonce_send: KeyNonce,
+        key_nonce_recv: KeyNonce,
+        capacity: usize,
+    ) -> Self {
+        Self {
+            reader: BoxStreamRead::new(read_stream, key_nonce_recv, capacity),
+            writer: BoxStreamWrite::new(write_stream, key_nonce_send, capacity),
+        }
+    }
+
     pub fn from_handshake(
         read_stream: R,
         write_stream: W,
@@ -67,10 +80,7 @@ impl<R: Read + Unpin, W: Write + Unpin> BoxStream<R, W> {
         capacity: usize,
     ) -> Self {
         let (key_nonce_send, key_nonce_recv) = KeyNonce::from_handshake(handshake_complete);
-        Self {
-            reader: BoxStreamRead::new(read_stream, key_nonce_recv, capacity),
-            writer: BoxStreamWrite::new(write_stream, key_nonce_send, capacity),
-        }
+        Self::new(read_stream, write_stream, key_nonce_send, key_nonce_recv, capacity)
     }
 }
 


### PR DESCRIPTION
This PR has two parts:
- Unify the sync/async implementations.  Now both boxstreams can be created with `new` and `from_handshake`.  And all handshake functions take the stream by reference.
- Add net and net_fragment tests to the async boxstream implementation. 