### PR TITLE
Closes #45, closes #46, closes #48 rust build

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -11,6 +11,12 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --all-features --verbose
+      run: RUSTFLAGS="-D warnings" cargo build --verbose --all-features --all-targets
+    - name: Build no features
+      run: cargo build --verbose 
+    - name: Build sync
+      run: cargo build --verbose --features "sync"
+    - name: Build async_std
+      run: cargo build --verbose --features "async_std"
+    - name: Build async_std tokio_compat
+      run: cargo build --verbose --features "async_std tokio_compat"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    patch:
+      default:
+        enabled: no

--- a/examples/handshake-boxstream-bench-async.rs
+++ b/examples/handshake-boxstream-bench-async.rs
@@ -2,12 +2,11 @@ extern crate base64;
 extern crate kuska_handshake;
 
 use std::env;
-use async_std::io::{self, Read,Write};
+use async_std::io;
 use async_std::net::{TcpStream, TcpListener};
 
 use sodiumoxide::crypto::{auth, sign::ed25519};
 
-use kuska_handshake::KeyNonce;
 use kuska_handshake::async_std::{handshake_client, handshake_server, BoxStream, Error};
 
 const BUF_SIZE: usize = 0x8000;

--- a/src/async_std/circularbuffer.rs
+++ b/src/async_std/circularbuffer.rs
@@ -50,24 +50,6 @@ impl CircularBuffer {
         self.end = 0;
         self.len = 0;
     }
-    pub fn write_from<R: Read>(&mut self, reader : &mut R) -> io::Result<()> {        
-        let mut readed = 1;
-
-        loop {
-            if readed==0 || self.len == self.buffer.len() {
-                return Ok(())
-            } else if self.start <= self.end {
-                // write at %end -> end_buffer 
-                readed = reader.read(&mut self.buffer[self.end..])?;
-                self.end = (readed + self.end) % self.buffer.len();
-            } else {
-                // write at %end -> %start
-                readed = reader.read(&mut self.buffer[self.end..self.start])?;
-                self.end += readed;
-            }
-            self.len += readed;
-        }
-    }
 
     pub fn defrag(&mut self) {
         if self.len > 0 {
@@ -276,7 +258,11 @@ mod test {
         // skip 3
         b.skip(3);
         assert_eq!("08", hex::encode(b.contiguous_value()));
-        
+
+        // clear
+        b.clear();
+        assert_eq!("", hex::encode(b.contiguous_value()));
+
         Ok(())
     }
 

--- a/src/boxstream.rs
+++ b/src/boxstream.rs
@@ -5,6 +5,8 @@ use crate::handshake::HandshakeComplete;
 
 use core::fmt;
 use core::{cmp, mem};
+use std::convert;
+use std::io;
 use sodiumoxide::crypto::{auth, hash::sha256, scalarmult::curve25519, secretbox};
 
 // Length of encrypted body (with MAC detached)
@@ -18,6 +20,19 @@ pub const MSG_HEADER_LEN: usize = MSG_HEADER_DEC_LEN + secretbox::MACBYTES;
 pub enum Error {
     DecryptHeaderSecretbox,
     DecryptBodySecretbox,
+}
+
+impl std::error::Error for Error {}
+
+impl convert::From<Error> for io::Error {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::DecryptHeaderSecretbox => {
+                Self::new(io::ErrorKind::InvalidInput, error)
+            }
+            Error::DecryptBodySecretbox => Self::new(io::ErrorKind::InvalidInput, error),
+        }
+    }
 }
 
 impl fmt::Display for Error {

--- a/src/sync/boxstream.rs
+++ b/src/sync/boxstream.rs
@@ -1,22 +1,9 @@
-use std::{convert, io, io::Read, io::Write};
+use std::{io, io::Read, io::Write};
 
 use crate::boxstream::{
-    self, BoxStreamRecv, BoxStreamSend, KeyNonce, MSG_BODY_MAX_LEN, MSG_HEADER_LEN,
+    BoxStreamRecv, BoxStreamSend, KeyNonce, MSG_BODY_MAX_LEN, MSG_HEADER_LEN,
 };
 use crate::handshake::HandshakeComplete;
-
-impl std::error::Error for boxstream::Error {}
-
-impl convert::From<boxstream::Error> for io::Error {
-    fn from(error: boxstream::Error) -> Self {
-        match error {
-            boxstream::Error::DecryptHeaderSecretbox => {
-                Self::new(io::ErrorKind::InvalidInput, error)
-            }
-            boxstream::Error::DecryptBodySecretbox => Self::new(io::ErrorKind::InvalidInput, error),
-        }
-    }
-}
 
 pub struct BoxStreamRead<R> {
     stream: R,


### PR DESCRIPTION
Solves some issues regarding CI compilation:
- #45 compilation fails when only `async_std` feature is specified
- #46 unnecessary unit tests
- #48 do not allow builds with warnings

additionally patch coverage check (see https://docs.codecov.io/docs/commit-status#section-patch-status) has been disabled, since easely breaks coverage when refactor.