### PR TITLE
nicer codecov threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,8 @@
 coverage:
   status:
+    project:
+      default:
+        treshold: 1%
     patch:
       default:
         enabled: no


### PR DESCRIPTION
Code coverage threshold was 0%, updated to 1% to avoid errors on minimal code changes.